### PR TITLE
fix: swap asm_estimated_kb and activated_at read order in program_info

### DIFF
--- a/src/state/program.rs
+++ b/src/state/program.rs
@@ -375,8 +375,8 @@ where
             let init_cost = u16::from_be_bytes([data[2], data[3]]);
             let cached_cost = u16::from_be_bytes([data[4], data[5]]);
             let footprint = u16::from_be_bytes([data[6], data[7]]);
-            let activated_at = u32::from_be_bytes([0, data[8], data[9], data[10]]);
-            let asm_estimated_kb = u32::from_be_bytes([0, data[11], data[12], data[13]]);
+            let asm_estimated_kb = u32::from_be_bytes([0, data[8], data[9], data[10]]);
+            let activated_at = u32::from_be_bytes([0, data[11], data[12], data[13]]);
             let cached = data[14] != 0;
 
             return Ok(Some(ProgramInfo {


### PR DESCRIPTION
The read order in program_info was swapped relative to the write order in save_program_info, causing activated_at to contain the asm size and vice versa. This led to incorrect age calculations that made freshly activated programs appear expired, causing codehashVersion and related queries to revert.