### PR TITLE
fix: touch ARBOS_STATE_ADDRESS after sstore so CacheDB persists stora…

### DIFF
--- a/src/precompiles/arb_wasm.rs
+++ b/src/precompiles/arb_wasm.rs
@@ -850,9 +850,9 @@ mod tests {
     use std::convert::Infallible;
 
     use revm::{
-        Journal,
+        Database, DatabaseCommit, Journal,
         context::{BlockEnv, ContextTr},
-        database::EmptyDBTyped,
+        database::{CacheDB, EmptyDB, EmptyDBTyped},
         primitives::keccak256,
         state::Bytecode,
     };
@@ -880,10 +880,21 @@ mod tests {
         }
     }
 
-    fn deploy_program(
-        context: &mut ArbitrumContext<EmptyDBTyped<Infallible>>,
-        wat: &[u8],
-    ) -> Address {
+    fn setup_cachedb() -> ArbitrumContext<CacheDB<EmptyDB>> {
+        let db = CacheDB::new(EmptyDB::default());
+
+        ArbitrumContext {
+            journaled_state: Journal::new(db),
+            block: BlockEnv::default(),
+            cfg: ArbitrumConfig::default(),
+            tx: ArbitrumTransaction::default(),
+            chain: (),
+            local: ArbitrumLocalContext::default(),
+            error: Ok(()),
+        }
+    }
+
+    fn deploy_program<DB: Database>(context: &mut ArbitrumContext<DB>, wat: &[u8]) -> Address {
         let wasm_bytes = wat2wasm(wat).unwrap();
 
         let wasm = brotli::compress(&wasm_bytes, 11, 22, brotli::Dictionary::Empty).unwrap();
@@ -1006,5 +1017,91 @@ mod tests {
         let asm_size = IArbWasm::codehashAsmSizeCall::abi_decode_returns(&result.output)
             .expect("decode codehashAsmSize");
         assert!(asm_size > 0, "asm size should be non-zero");
+    }
+
+    /// Regression test: verifies that ARBOS_STATE_ADDRESS storage writes survive
+    /// `Journal::finalize()` + `CacheDB::commit()`. Before the `touch_account` fix,
+    /// CacheDB::commit() skipped untouched accounts, silently discarding storage.
+    #[test]
+    fn test_activate_persists_after_commit() {
+        use crate::state::{ArbState, ArbStateGetter, arbos_state::ArbosStateParams};
+
+        let mut context = setup_cachedb();
+        context.cfg.disable_auto_activate = true;
+        context.cfg.disable_auto_cache = true;
+
+        // Initialize ArbOS state with default params
+        context
+            .arb_state(None, false)
+            .initialize(&ArbosStateParams::default())
+            .expect("failed to initialize ArbOS state");
+
+        let wat = include_bytes!("../../test-data/memory.wat");
+        let program_address = deploy_program(&mut context, wat);
+
+        // Get the code hash for later queries
+        let code_hash = context
+            .arb_state(None, false)
+            .code_hash(program_address)
+            .expect("failed to get code hash");
+
+        // Activate the program via ArbWasm precompile
+        let arb_wasm_addr = address!("0x0000000000000000000000000000000000000071");
+        let call_value = U256::from(100_000_000_000_000u64);
+        context
+            .journal_mut()
+            .balance_incr(arb_wasm_addr, call_value)
+            .unwrap();
+
+        let input = IArbWasm::activateProgramCall::abi_encode(&IArbWasm::activateProgramCall {
+            program: program_address,
+        });
+
+        let result = ArbWasmPrecompile::run(
+            &mut context,
+            &input,
+            &arb_wasm_addr,
+            address!("0x000000000000000000000000000000000000c0de"),
+            call_value,
+            false,
+            10_000_000,
+        )
+        .unwrap();
+        assert!(result.is_ok(), "activation failed: {:?}", result.result);
+
+        let activation = IArbWasm::activateProgramCall::abi_decode_returns(&result.output)
+            .expect("decode activation result");
+        assert!(activation.version > 0, "activated version should be > 0");
+
+        // Simulate transaction commit: finalize journal state, then commit to CacheDB.
+        // This is the code path that previously lost ARBOS_STATE_ADDRESS storage writes.
+        let state = context.journaled_state.finalize();
+        context.journaled_state.db_mut().commit(state);
+
+        // Query codehashVersion after commit — should still return the activation version
+        let input = IArbWasm::codehashVersionCall::abi_encode(&IArbWasm::codehashVersionCall {
+            codehash: code_hash,
+        });
+        let result = ArbWasmPrecompile::run(
+            &mut context,
+            &input,
+            &arb_wasm_addr,
+            address!("0x000000000000000000000000000000000000c0de"),
+            U256::ZERO,
+            true,
+            10_000_000,
+        )
+        .unwrap();
+        assert!(
+            result.is_ok(),
+            "codehashVersion should succeed after commit, got: {:?}",
+            result.result
+        );
+        let version = IArbWasm::codehashVersionCall::abi_decode_returns(&result.output)
+            .expect("decode codehashVersion");
+        assert_eq!(
+            version, activation.version,
+            "codehashVersion should match activation version after commit"
+        );
     }
 }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -368,6 +368,13 @@ where
             .sstore(ARBOS_STATE_ADDRESS, self.slot.into(), value)
             .unwrap();
 
+        // Mark ARBOS_STATE_ADDRESS as touched so CacheDB::commit persists its storage changes.
+        // Without this, sstore modifies the journal but the account remains untouched,
+        // causing CacheDB::commit to skip the account and discard all storage writes.
+        self.context
+            .journal_mut()
+            .touch_account(ARBOS_STATE_ADDRESS);
+
         Ok(())
     }
 }


### PR DESCRIPTION
revm's sstore does not mark the target account as touched. CacheDB::commit skips untouched accounts, silently discarding all storage writes to ARBOS_STATE_ADDRESS. This caused activateProgram data to be lost, making subsequent queries like codehashVersion revert with ProgramNotActivated.