### PR TITLE
fix: return KECCAK_EMPTY instead of B256::ZERO for non-existent accounts in Stylus codehash, and read gas parameter in AccountCode handler

### DIFF
--- a/src/stylus_api.rs
+++ b/src/stylus_api.rs
@@ -645,15 +645,31 @@ where
 
             EvmApiMethod::AccountCode => {
                 let address = buffer::take_address(&mut data);
+                let gas_left = buffer::take_u64(&mut data);
+
+                // Load account info (without code) to determine warm/cold and compute gas
+                let account = context.load_account_code_hash(address).unwrap();
+                let gas = wasm_account_touch(&mut *context, account.is_cold, true);
+
+                // If not enough gas, return empty code (matching nitro behavior)
+                if gas_left < gas {
+                    return (vec![], VecReader::new(vec![]), ArbGas(gas));
+                }
+
                 let code = context.load_account_code(address).unwrap();
-                let gas = wasm_account_touch(context, code.is_cold, true);
                 (vec![], VecReader::new(code.to_vec()), ArbGas(gas))
             }
 
             EvmApiMethod::AccountCodeHash => {
                 let address = buffer::take_address(&mut data);
-                let code_hash = context.load_account_code_hash(address).unwrap();
-                let gas = wasm_account_touch(context, code_hash.is_cold, false);
+                // Use load_account to get the raw code_hash (KECCAK_EMPTY for no-code
+                // accounts) instead of Host::load_account_code_hash which applies
+                // EIP-1052 EXTCODEHASH semantics (B256::ZERO for empty accounts).
+                // The Stylus host wraps StateDB.GetCodeHash, not the EXTCODEHASH opcode.
+                let account = context.journal_mut().load_account(address).unwrap();
+                let is_cold = account.is_cold;
+                let code_hash = account.data.info.code_hash;
+                let gas = wasm_account_touch(&mut *context, is_cold, false);
                 (code_hash.to_vec(), VecReader::new(vec![]), ArbGas(gas))
             }
 

--- a/tests/account_info.rs
+++ b/tests/account_info.rs
@@ -186,13 +186,13 @@ fn test_e2e_account_codehash_eoa() {
                 32,
                 "codehash output should be 32 bytes"
             );
-            // EOA should have empty code hash (keccak256 of empty = c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
+            // Stylus account_codehash wraps StateDB.GetCodeHash (not the EXTCODEHASH opcode),
+            // so funded EOAs should return KECCAK_EMPTY — the raw code_hash field.
             let expected_empty_hash: B256 = keccak256([]);
             let code_hash = B256::from_slice(output.data().as_ref());
-            // Note: Empty accounts may return zero hash, funded EOAs return empty code hash
-            assert!(
-                code_hash == expected_empty_hash || code_hash == B256::ZERO,
-                "EOA code hash should be empty hash or zero, got {:?}",
+            assert_eq!(
+                code_hash, expected_empty_hash,
+                "EOA code hash should be KECCAK_EMPTY, got {:?}",
                 code_hash
             );
         }
@@ -286,11 +286,15 @@ fn test_e2e_account_codehash_nonexistent() {
                 "codehash output should be 32 bytes"
             );
             let code_hash = B256::from_slice(output.data().as_ref());
-            // Non-existent account should return zero hash per EIP-1052
+            // Stylus account_codehash wraps StateDB.GetCodeHash (not the EXTCODEHASH opcode).
+            // Non-existent accounts have code_hash = KECCAK_EMPTY in their default AccountInfo,
+            // so the Stylus host should return KECCAK_EMPTY, NOT B256::ZERO.
+            // (EIP-1052 EXTCODEHASH returns zero for non-existent accounts, but that's the
+            // opcode semantics — the Stylus host bypasses that and returns the raw field.)
+            let expected_empty_hash: B256 = keccak256([]);
             assert_eq!(
-                code_hash,
-                B256::ZERO,
-                "non-existent account code hash should be zero"
+                code_hash, expected_empty_hash,
+                "non-existent account code hash should be KECCAK_EMPTY (not B256::ZERO)"
             );
         }
         ExecutionResult::Revert { output, .. } => {


### PR DESCRIPTION
AccountCodeHash: Host::load_account_code_hash applies EIP-1052 EXTCODEHASH opcode semantics, returning B256::ZERO for empty accounts. But the Stylus host wraps StateDB.GetCodeHash which returns the raw code_hash field (KECCAK_EMPTY for accounts without code). Use journal.load_account directly to return the raw code_hash, matching nitro behavior.

AccountCode: the handler was ignoring the gas_left parameter sent in the request. Nitro checks gas_left < cost and returns empty code when insufficient. Without this check, account_code_size would OOG instead of gracefully returning 0.